### PR TITLE
Add Alex Linter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -4,16 +4,13 @@ Hello!
 
 This is just a loose collection of "must-read" or "nice-to-read" documents to create common ground for code practices. Think of it as a poor man's [Thoughtbot Playbook](https://thoughtbot.com/playbook). Which is going to be our first resource:
 
-
 ## The Thoughtbot Playbook
 
 [An high-level overview of app development.](https://thoughtbot.com/playbook)
 
-
 ## The 12-factor App
 
 [All IR projects should be 12 factor](https://12factor.net/). We should emphasize developer ergonomics and ease of deployment.
-
 
 ## Code Review
 
@@ -22,31 +19,29 @@ This is just a loose collection of "must-read" or "nice-to-read" documents to cr
 [Code review process & etiquette is extremely important](https://hypothes.is/blog/code-review-in-remote-teams/).
 It is one of the most critical growth channels for engineers, new or experienced.
 
-
 ## Git workflows
 
 I prefer the rebase flow, but it's likely we'll probably be working off of a vanilla merge or fork flow. Here is information about both.
 
-- [Overview of rebase workflow](https://www.atlassian.com/git/tutorials/merging-vs-rebasing)
-- [Forking workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/forking-workflow)
-- [Configuring git with ssh](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/)
-
+* [Overview of rebase workflow](https://www.atlassian.com/git/tutorials/merging-vs-rebasing)
+* [Forking workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/forking-workflow)
+* [Configuring git with ssh](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/)
 
 ## Style Guide
 
 [We use the AirBnb style guide](https://github.com/airbnb/javascript). It is recommended to actually read through a some of it - they provide explanations for the various rules which can be enlightening. The explanations reveal an astounding attention to detail and care for craft that we should strive to emulate.
-
 
 ## How to write good code
 
 Can be surprisingly difficult, even for experienced engineers. Some will tell you to read a classic Java volume called "Clean Code", which is a terrific book. [However, there's a fantastic, simplified javascript version that emphasizes clean code principles right on github.](https://github.com/ryanmcdermott/clean-code-javascript)
 
 Some misc tips from me:
- - To become a greater javascript programmer, see if you can write code without using if or switch statements.
- - Emphasize pure functions over mutation. In fact, see if you can write code without ever using mutation or ever using a let statement.
- - Comments are apologies for not writing your code clearly enough. Use them wisely.
- - Don't shy away from spreading things out and splitting modules into separate files. As a loose rule, a single file should never be longer than 200 lines. For hard mode, try 100 lines.
- - Don't leave commented out code in a master branch, ever.
- - Don't leave TODOs in the code, ever. Represent TODO items as tickets on the project kanban board.
- - Don't put console logs in your code...except inside your logger module. Think about logging systematically than random output.
- - The clean code manual was written for OOP. Keep in mind JS is strongest when written in a terse, functional style. There was a significant controversy years ago that ES6 classes would lead JS engineers in the wrong direction with their code style. After seeing ES6 mature and its usage spread, I have to agree.
+
+* To become a greater javascript programmer, see if you can write code without using if or switch statements.
+* Emphasize pure functions over mutation. In fact, see if you can write code without ever using mutation or ever using a let statement.
+* Comments are apologies for not writing your code clearly enough. Use them wisely.
+* Don't shy away from spreading things out and splitting modules into separate files. As a loose rule, a single file should never be longer than 200 lines. For hard mode, try 100 lines.
+* Don't leave commented out code in a master branch, ever.
+* Don't leave TODOs in the code, ever. Represent TODO items as tickets on the project kanban board.
+* Don't put console logs in your code...except inside your logger module. Think about logging systematically than random output.
+* The clean code manual was written for OOP. Keep in mind JS is strongest when written in a terse, functional style. There was a significant controversy years ago that ES6 classes would lead JS engineers in the wrong direction with their code style. After seeing ES6 mature and its usage spread, I have to agree.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Hello!",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "documentation-linting": "alex"
   },
   "repository": {
     "type": "git",
@@ -15,5 +16,8 @@
   "bugs": {
     "url": "https://github.com/inrhythm/Open-Source-Resources/issues"
   },
-  "homepage": "https://github.com/inrhythm/Open-Source-Resources#readme"
+  "homepage": "https://github.com/inrhythm/Open-Source-Resources#readme",
+  "dependencies": {
+    "alex": "^5.1.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "lint:documentation": "alex"
+    "lint:documentation": "alex",
+    "precommit": "lint-staged"
   },
   "repository": {
     "type": "git",
@@ -19,5 +20,12 @@
   "homepage": "https://github.com/inrhythm/Open-Source-Resources#readme",
   "dependencies": {
     "alex": "^5.1.0"
+  },
+  "devDependencies": {
+    "husky": "^0.14.3",
+    "lint-staged": "^6.1.0"
+  },
+  "lint-staged": {
+    "*.md": ["alex", "git add"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "documentation-linting": "alex"
+    "lint:documentation": "alex"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "inrhythm-open-source-resources",
+  "version": "1.0.0",
+  "description": "Hello!",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/inrhythm/Open-Source-Resources.git"
+  },
+  "author": "InRhythm",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/inrhythm/Open-Source-Resources/issues"
+  },
+  "homepage": "https://github.com/inrhythm/Open-Source-Resources#readme"
+}


### PR DESCRIPTION
Fixes #3 

Add a markdown linter called [Alex](https://github.com/wooorm/alex) that makes sure our documentation is considerate. 

Additionally, set up git hooks with `lint-staged` and `husky` to make sure we are running this linter when we commit.